### PR TITLE
구독 및 관심사 기능 업데이트

### DIFF
--- a/prisma/mysql.schema.prisma
+++ b/prisma/mysql.schema.prisma
@@ -34,7 +34,7 @@ model User {
 // Subscriber 모델
 model Subscriber {
   id        Int      @id @default(autoincrement())
-  userId    Int
+  userId    Int      @unique // 사용자별 중복 구독 방지
   startedAt DateTime @default(now())
   endAt     DateTime?
 

--- a/src/mypage/mypage.controller.ts
+++ b/src/mypage/mypage.controller.ts
@@ -1,7 +1,9 @@
 import {
   Controller,
   Get,
+  Patch,
   Req,
+  Body,
   UnauthorizedException,
   UseGuards,
 } from '@nestjs/common';
@@ -49,6 +51,31 @@ export class MyPageController {
   async getSubscriptionHistory(@Req() req) {
     const userId = this.validateAndParseUserId(req.user?.userId);
     return this.myPageService.getSubscriptionHistory(userId);
+  }
+
+  /**
+   * 관심사 조회
+   */
+  @Get('interests')
+  async getInterests(@Req() req) {
+    const userId = this.validateAndParseUserId(req.user?.userId);
+    return this.myPageService.getInterests(userId);
+  }
+
+  /**
+   * 관심사 수정
+   */
+  @Patch('interests')
+  async updateInterests(@Req() req, @Body('interests') interests: string[]) {
+    const userId = this.validateAndParseUserId(req.user?.userId);
+    const validInterests = ['정치', '사회', 'IT'];
+
+    // 유효성 검사
+    if (!interests || interests.some((interest) => !validInterests.includes(interest))) {
+      throw new UnauthorizedException('Invalid interests provided');
+    }
+
+    return this.myPageService.updateInterests(userId, interests);
   }
 
   /**

--- a/src/subscriber/subscriber.controller.ts
+++ b/src/subscriber/subscriber.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   Get,
   Post,
+  Delete,
   Body,
   Query,
   ParseIntPipe,
@@ -25,7 +26,7 @@ export class SubscriberController {
    * 구독 종료
    * @param userId 사용자 ID
    */
-  @Post('end')
+  @Delete('end')
   async endSubscription(@Body('userId', ParseIntPipe) userId: number) {
     return this.subscriberService.endSubscription(userId);
   }
@@ -40,7 +41,7 @@ export class SubscriberController {
   }
 
   /**
-   * 전체 구독 기록 조회
+   * 구독 기록 조회
    * @param userId 사용자 ID
    */
   @Get('history')

--- a/src/subscriber/subscriber.service.ts
+++ b/src/subscriber/subscriber.service.ts
@@ -1,12 +1,16 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, ConflictException } from '@nestjs/common';
 import { MysqlPrismaService } from 'prisma/mysql.service'; // MysqlPrismaService 사용
 
 @Injectable()
 export class SubscriberService {
   constructor(private readonly prisma: MysqlPrismaService) {}
 
-  // 구독 시작
+  /**
+   * 구독 시작
+   * @param userId 사용자 ID
+   */
   async startSubscription(userId: number) {
+    // 유저 존재 여부 확인
     const userExists = await this.prisma.user.findUnique({
       where: { id: userId },
     });
@@ -15,48 +19,66 @@ export class SubscriberService {
       throw new NotFoundException(`User with ID ${userId} does not exist.`);
     }
 
-    return await this.prisma.subscriber.create({
-      data: {
-        userId,
-        startedAt: new Date(),
-      },
+    // 중복 구독 방지
+    const existingSubscription = await this.prisma.subscriber.findUnique({
+      where: { userId },
     });
+
+    if (existingSubscription && !existingSubscription.endAt) {
+      throw new ConflictException('User is already subscribed.');
+    }
+
+    // 구독 생성 또는 기존 구독 갱신
+    return existingSubscription
+      ? this.prisma.subscriber.update({
+          where: { id: existingSubscription.id },
+          data: { startedAt: new Date(), endAt: null },
+        })
+      : this.prisma.subscriber.create({
+          data: {
+            userId,
+            startedAt: new Date(),
+          },
+        });
   }
 
-  // 구독 종료
+  /**
+   * 구독 종료
+   * @param userId 사용자 ID
+   */
   async endSubscription(userId: number) {
-    const userExists = await this.prisma.user.findUnique({
-      where: { id: userId },
+    // 활성 구독 확인
+    const activeSubscription = await this.prisma.subscriber.findFirst({
+      where: { userId, endAt: null },
     });
 
-    if (!userExists) {
-      throw new NotFoundException(`User with ID ${userId} does not exist.`);
+    if (!activeSubscription) {
+      throw new NotFoundException('No active subscription found.');
     }
 
-    return await this.prisma.subscriber.updateMany({
-      where: { userId, endAt: null },
+    // 구독 종료
+    return this.prisma.subscriber.update({
+      where: { id: activeSubscription.id },
       data: { endAt: new Date() },
     });
   }
 
-  // 현재 구독 상태 조회
+  /**
+   * 현재 구독 상태 조회
+   * @param userId 사용자 ID
+   */
   async getSubscriptionStatus(userId: number) {
-    const userExists = await this.prisma.user.findUnique({
-      where: { id: userId },
-    });
-
-    if (!userExists) {
-      throw new NotFoundException(`User with ID ${userId} does not exist.`);
-    }
-
-    const subscription = await this.prisma.subscriber.findFirst({
+    const activeSubscription = await this.prisma.subscriber.findFirst({
       where: { userId, endAt: null },
     });
 
-    return subscription ? { active: true } : { active: false };
+    return activeSubscription ? { active: true } : { active: false };
   }
 
-  // 전체 구독 기록 조회
+  /**
+   * 구독 기록 조회
+   * @param userId 사용자 ID
+   */
   async getSubscriptionHistory(userId: number) {
     const userExists = await this.prisma.user.findUnique({
       where: { id: userId },


### PR DESCRIPTION
## 작업 개요

- 중복 구독 방지 기능 추가.
- 마이페이지 관심사 조회 및 수정 기능 추가.
   => Test Category : "정치", "사회", "IT" 


## PR 유형

어떤 변경 사항이 있나요?

-    새로운 기능 추가
-   버그 수정

## 주요 변경 사항

-   한 계정으로 중복 구독되는 기존 오류 해결하였습니다.
-   마이페이지에서 관심사 조회 및 수정할 수 있는 기능 추가하였습니다.


### 테스트 결과 (선택)
![스크린샷 2025-01-24 오후 9 33 18](https://github.com/user-attachments/assets/55bce602-1424-43c1-9f43-08c2156cc365)
![스크린샷 2025-01-24 오후 9 33 38](https://github.com/user-attachments/assets/001c895a-cfc9-40e6-8927-8630e3538c2e)
![스크린샷 2025-01-24 오후 9 34 03](https://github.com/user-attachments/assets/df9497db-4f12-470a-9642-7c086abaaade)

-   Postman 에서 확인 가능합니다 ! 

## 기타 참고 사항

**- 스키마 변동사항 적용 테스트 전에 꼭 부탁드립니다 !**
- npx prisma generate --schema=prisma/mysql.schema.prisma
- npx prisma migrate dev --schema=prisma/mysql.schema.prisma --name (사용자지정)
