### PR TITLE
구독 기능 분리 완료

### DIFF
--- a/prisma/mysql.schema.prisma
+++ b/prisma/mysql.schema.prisma
@@ -37,6 +37,7 @@ model Subscriber {
   userId    Int      @unique // 사용자별 중복 구독 방지
   startedAt DateTime @default(now())
   endAt     DateTime?
+  status    String   @default("active") // 상태 : active, paused, cancelled
 
   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 

--- a/src/subscriber/subscriber.controller.ts
+++ b/src/subscriber/subscriber.controller.ts
@@ -23,7 +23,7 @@ export class SubscriberController {
   }
 
   /**
-   * 구독 일시정지 
+   * 구독 일시정지
    * @param userId 사용자 ID
    */
   @Post('pause')

--- a/src/subscriber/subscriber.controller.ts
+++ b/src/subscriber/subscriber.controller.ts
@@ -23,12 +23,21 @@ export class SubscriberController {
   }
 
   /**
-   * 구독 종료
+   * 구독 일시정지 
    * @param userId 사용자 ID
    */
-  @Delete('end')
-  async endSubscription(@Body('userId', ParseIntPipe) userId: number) {
-    return this.subscriberService.endSubscription(userId);
+  @Post('pause')
+  async pauseSubscription(@Body('userId', ParseIntPipe) userId: number) {
+    return this.subscriberService.pauseSubscription(userId);
+  }
+
+  /**
+   * 구독 해지
+   * @param userId 사용자 ID
+   */
+  @Delete('cancel')
+  async cancelSubscription(@Body('userId', ParseIntPipe) userId: number) {
+    return this.subscriberService.cancelSubscription(userId);
   }
 
   /**


### PR DESCRIPTION
## 작업 개요

구독 기능 분리 작업. 

1. 일시정지.
- 새로운 뉴스레터 받지 않음. 
- 구독과 관련된 데이터는 남아있음.

2. 종료.
- 새로운 뉴스레터 받지 않음.
- 구독과 관련된 데이터 삭제.


## PR 유형

어떤 변경 사항이 있나요?

-   새로운 기능 추가


## 주요 변경 사항

-   구독 기능 분리 완료하였습니다. 

### 테스트 결과 (선택)
![스크린샷 2025-01-25 오후 4 24 45](https://github.com/user-attachments/assets/2a3d5533-d1ef-4ec4-b809-025b7c75aa06)
![스크린샷 2025-01-25 오후 4 30 21](https://github.com/user-attachments/assets/1f6bbe02-c1be-4091-85b9-1eeed491fc9f)
![스크린샷 2025-01-25 오후 4 31 43](https://github.com/user-attachments/assets/de3829b2-e1cd-4446-a8a5-5e7d2f8d7613)

-   Postman으로 테스트 완료 ! 
-   스키마 변경되었으니 꼭 스키마 적용해주시고 테스트 해주세요 :)

## 기타 참고 사항

-   구독 활성화 : Post,  http://localhost:3001/subscribers/start
                    -> Body : { "userId": 1(값) } 

-       일시정지 : Post,  http://localhost:3001/subscribers/pause
                    -> Body : { "userId": 1(값) }  
   ** 일시정지 해제는 다시 활성화로 가능.

-             종료 : Delete, http://localhost:3001/subscribers/cancel
                    -> Body : { "userId": 1(값) }  

-             조회 : Get, http://localhost:3001/subscribers/status?userId=1
                    -> Body : 없음.