### PR TITLE
 feat: refresh토큰 및 로그아웃시에 토큰 삭제, 로그인시 쿠키로 acces_token, refresh_token …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "cache-manager-redis-store": "^3.0.1",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
+        "cookie-parser": "^1.4.7",
         "dayjs": "^1.11.13",
         "dotenv": "^16.4.7",
         "glob": "^9.3.5",
@@ -6376,6 +6377,28 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
       "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "cache-manager-redis-store": "^3.0.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
+    "cookie-parser": "^1.4.7",
     "dayjs": "^1.11.13",
     "dotenv": "^16.4.7",
     "glob": "^9.3.5",

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -2,179 +2,140 @@ import {
   Controller,
   Get,
   Post,
-  Body,
   Req,
   Res,
   UseGuards,
   UnauthorizedException,
-  Options,
 } from '@nestjs/common';
-import { Response } from 'express';
+import { Response, Request } from 'express';
 import { AuthService } from './auth.service';
 import { AuthGuard } from '@nestjs/passport';
+
+interface OAuthUser {
+  googleSub: string;
+  email: string;
+  username: string;
+  profileImg: string | null;
+}
 
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
-  /**
-   * Preflight 요청 허용 (CORS 문제 해결)
-   */
-  @Options('*')
-  preflight(@Res() res: Response) {
-    res.header('Access-Control-Allow-Origin', 'http://localhost:3000');
-    res.header('Access-Control-Allow-Credentials', 'true');
-    res.header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-    res.header('Access-Control-Allow-Headers', 'Content-Type, Authorization');
-    res.sendStatus(204);
-  }
-
-  /**
-   * Google OAuth 로그인 시작
-   */
   @Get('google')
   @UseGuards(AuthGuard('google'))
   async googleLogin() {
     return { message: 'Redirecting to Google OAuth...' };
   }
 
-  /**
-   * Google OAuth 콜백 처리
-   */
   @Get('google/callback')
   @UseGuards(AuthGuard('google'))
-  async googleCallback(@Req() req, @Res() res: Response) {
-    try {
-      const { googleSub, email, username, profileImg } = req.user;
+  async googleCallback(@Req() req: Request, @Res() res: Response) {
+    if (!req.user) {
+      throw new UnauthorizedException('OAuth user not found');
+    }
 
-      // 사용자 검증 또는 생성
-      const user = await this.authService.validateOrCreateGoogleUser(
-        googleSub,
-        email,
-        username,
-        profileImg,
-      );
+    const { googleSub, email, username, profileImg } = req.user as OAuthUser;
 
-      if (!user) {
-        throw new UnauthorizedException('User validation failed');
-      }
+    const user = await this.authService.validateOrCreateGoogleUser(
+      googleSub,
+      email,
+      username,
+      profileImg,
+    );
 
-      // JWT 생성
-      const token = this.authService.generateJwtToken(user);
+    if (!user) {
+      return res.status(401).json({ message: 'User validation failed' });
+    }
 
-      // 쿠키 설정
-      res.cookie('access_token', token, {
-        httpOnly: true,
-        secure: process.env.NODE_ENV === 'production', // HTTPS에서만 전송
-        sameSite: 'lax', // CSRF 방지
-        maxAge: 1000 * 60 * 60 * 24, // 24시간 유지
-      });
+    const { accessToken, refreshToken } =
+      await this.authService.generateJwtTokens(user);
 
-      res.cookie('user_id', user.id, {
-        httpOnly: true,
-        secure: process.env.NODE_ENV === 'production', // HTTPS에서만 전송
-        sameSite: 'lax', // CSRF 방지
-        maxAge: 1000 * 60 * 60 * 24, // 24시간 유지
-      });
+    res.cookie('access_token', accessToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: 1000 * 60 * 60 * 24,
+    });
 
-      // CORS 헤더 설정
-      const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:3000';
-      res.header('Access-Control-Allow-Origin', frontendUrl);
-      res.header('Access-Control-Allow-Credentials', 'true');
+    res.cookie('refresh_token', refreshToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: 7 * 24 * 60 * 60 * 1000,
+    });
 
-      // HTML 반환 (한 번의 응답으로 모든 작업 수행)
-      res.send(`
+    res.cookie('user_id', user.id, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: 1000 * 60 * 60 * 24,
+    });
+
+    const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:3000';
+
+    return res.send(`
       <html>
         <body>
           <h1>OAuth Success</h1>
           <p>Authentication successful. Closing window...</p>
           <script>
             try {
-              const token = '${token}';
+              const token = '${accessToken}';
               const user = ${JSON.stringify(user)
-                .replace(/\\/g, '\\\\') // 역슬래시 이스케이프
-                .replace(/'/g, "\\'")}'; // 작은 따옴표 이스케이프
+                .replace(/\\/g, '\\\\')
+                .replace(/'/g, "\\'")};
 
-              console.log('OAuth Success: Token and User received');
-
-              // 사용자 정보를 부모 창에 전송
               if (window.opener) {
                 window.opener.postMessage({ type: 'oauthSuccess', token, user }, '${frontendUrl}');
               } else if (window.parent) {
                 window.parent.postMessage({ type: 'oauthSuccess', token, user }, '${frontendUrl}');
-              } else {
-                console.warn('No opener or parent window found');
               }
 
-              // 브라우저에 표시
               document.body.innerHTML += '<h3>Information sent to parent window.</h3>';
-
-              // 창 닫기 시도
               setTimeout(() => window.close(), 2000);
-            } catch (err) {
-              console.error('Error handling OAuth success:', err);
-            }
+            } catch (err) {}
           </script>
         </body>
       </html>
     `);
-    } catch (error) {
-      console.error('Error in Google OAuth Callback:', error.message);
-      res.status(400).send(`
-      <html>
-        <body>
-          <h1>Authentication failed</h1>
-          <p>Error: ${error.message}</p>
-          <script>
-            console.error('Authentication failed: ${error.message}');
-            alert('Authentication failed. Please try again.');
-            window.close();
-          </script>
-        </body>
-      </html>
-    `);
-    }
   }
 
-  /**
-   * 로그아웃 처리
-   */
+  @Get('refresh')
+  async refresh(@Req() req: Request, @Res() res: Response) {
+    const refreshToken = req.cookies['refresh_token'];
+    if (!refreshToken) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+
+    const newAccessToken =
+      await this.authService.refreshAccessToken(refreshToken);
+    if (!newAccessToken) {
+      return res.status(401).json({ message: 'Invalid refresh token' });
+    }
+
+    res.cookie('access_token', newAccessToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: 60 * 60 * 1000,
+    });
+
+    return res.json({ message: 'Token refreshed' });
+  }
+
   @Post('logout')
-  logout(@Res() res: Response) {
-    const isProduction = process.env.NODE_ENV === 'production';
+  async logout(@Req() req: Request, @Res() res: Response) {
+    const refreshToken = req.cookies['refresh_token'];
+    if (!refreshToken) {
+      return res.status(400).json({ message: 'No refresh token found' });
+    }
 
-    // access_token 쿠키 삭제
-    res.clearCookie('access_token', {
-      path: '/',
-      httpOnly: true,
-      secure: isProduction,
-      sameSite: 'lax',
-    });
+    await this.authService.removeRefreshToken(refreshToken);
 
-    // user_id 쿠키 삭제
-    res.clearCookie('user_id', {
-      path: '/',
-      httpOnly: true,
-      secure: isProduction,
-      sameSite: 'lax',
-    });
+    res.clearCookie('access_token');
+    res.clearCookie('refresh_token');
 
     return res.status(200).json({ message: 'Logged out successfully' });
-  }
-
-  /**
-   * 일반 로그인 처리
-   */
-  @Post('login')
-  async login(@Body() loginDto: { email: string; password: string }) {
-    const user = await this.authService.validateUser(
-      loginDto.email,
-      loginDto.password,
-    );
-    if (!user) {
-      return { message: 'Invalid credentials' };
-    }
-    const token = this.authService.generateJwtToken(user);
-    return { access_token: token };
   }
 }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -6,25 +6,30 @@ import { AuthController } from './auth.controller';
 import { JwtStrategy } from './jwt.strategy';
 import { GoogleStrategy } from './google.strategy';
 import { MysqlPrismaService } from 'prisma/mysql.service'; // MySQL Prisma Service
+import { ConfigModule, ConfigService } from '@nestjs/config';
 
 @Module({
   imports: [
     PassportModule.register({ defaultStrategy: 'jwt' }), // 기본 인증 전략 설정
-    JwtModule.register({
-      secret: process.env.JWT_SECRET || 'default_secret', // 환경 변수에서 JWT 비밀 키 가져오기
-      signOptions: { expiresIn: '1h' }, // 토큰 유효 기간 설정
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => ({
+        secret: configService.get<string>('JWT_SECRET') || 'default_secret',
+        signOptions: { expiresIn: '1h' },
+      }),
     }),
   ],
   controllers: [AuthController],
   providers: [
-    AuthService,       // 인증 서비스
-    JwtStrategy,       // JWT 인증 전략
-    GoogleStrategy,    // Google OAuth 전략
-    MysqlPrismaService // Prisma를 통한 DB 연동
+    AuthService, // 인증 서비스
+    JwtStrategy, // JWT 인증 전략
+    GoogleStrategy, // Google OAuth 전략
+    MysqlPrismaService, // Prisma를 통한 DB 연동
   ],
   exports: [
     AuthService, // AuthService를 다른 모듈에서 사용 가능
-    JwtModule,   // JwtModule을 다른 모듈에서 사용 가능
+    JwtModule, // JwtModule을 다른 모듈에서 사용 가능
   ],
 })
 export class AuthModule {}

--- a/src/auth/google.strategy.ts
+++ b/src/auth/google.strategy.ts
@@ -9,7 +9,7 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
       clientID: process.env.GOOGLE_CLIENT_ID,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET,
       callbackURL: process.env.GOOGLE_REDIRECT_URI,
-      scope: ['email', 'profile'], // 이메일 및 프로필 정보 요청
+      scope: ['email', 'profile'],
     });
   }
 
@@ -19,16 +19,15 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
     profile: any,
     done: VerifyCallback,
   ): Promise<any> {
-    const { id, emails, displayName, photos, name } = profile;
+    const { id, emails, displayName, photos } = profile;
 
     const user = {
       googleSub: id,
-      email: emails[0].value,
-      username: displayName || name.givenName,
-      profileImg: photos?.[0]?.value || null, // 이미지가 없으면 null 반환
-      accessToken,
+      email: emails?.[0]?.value || null,
+      username: displayName || null,
+      profileImg: photos?.[0]?.value || null,
     };
 
-    done(null, user);
+    return done(null, user);
   }
 }

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -1,12 +1,21 @@
 import { Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
+import { Request } from 'express';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
   constructor() {
     super({
-      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      jwtFromRequest: ExtractJwt.fromExtractors([
+        (req: Request) => {
+          let token = null;
+          if (req && req.cookies) {
+            token = req.cookies['access_token']; // 쿠키에서 `access_token` 가져오기
+          }
+          return token;
+        },
+      ]),
       ignoreExpiration: false,
       secretOrKey: process.env.JWT_SECRET,
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { NestFactory } from '@nestjs/core';
 import { ConfigService } from '@nestjs/config';
 import { AppModule } from './app.module';
+import cookieParser from 'cookie-parser'; // 쿠키파서 추가(리프레시토큰용)
 import './instruments';
 
 async function bootstrap() {
@@ -11,11 +12,11 @@ async function bootstrap() {
   const configService: ConfigService = app.get(ConfigService);
 
   // 환경 변수 및 기본값 설정
-  const frontendUrl: string = configService.get<string>(
-    'FRONTEND_URL',
-    // 'http://localhost:3000',
-  );
+  const frontendUrl: string = configService.get<string>('FRONTEND_URL');
   const port: number = configService.get<number>('PORT', 3001);
+
+  // 쿠키 파서 미들웨어 적용
+  app.use(cookieParser());
 
   // CORS 설정
   app.enableCors({
@@ -40,7 +41,6 @@ async function bootstrap() {
     next();
   });
 
-  // app.setGlobalPrefix('api/v1');
   // 서버 실행
   try {
     await app.listen(port, '0.0.0.0'); // 0.0.0.0으로 외부 네트워크 수신 허용


### PR DESCRIPTION
## 작업 개요

- Access Token + Refresh Token 적용하여 로그인 세션 유지 기능 추가.
- 쿠키(cookie-parser)를 사용해서 인증 토큰을 자동 관리할 수 있도록 함.


## PR 유형

어떤 변경 사항이 있나요?

-   새로운 기능 추가
-   버그 수정

## 주요 변경 사항

Google OAuth 로그인 후, Access Token + Refresh Token 발급 (Storage에서 확인 가능)

- **auth.controller.ts**
     a. OAuth 로그인 후 토큰을 쿠키로 저장하여 인증 유지 가능하도록 변경
     b. @Get  /auth/refresh 추가 → cookie : refresh_token= ~~~~을 이용한 access_token 자동 갱신 가능
     c. @Post /auth/logout 추가 → cookie : refresh_token= ~~~~ 삭제 후 세션 종료

-   **auth.service.ts**
     a. generateJwtTokens() → access token과 refresh token을 함께 생성하여 DB 저장
     b. refreshAccessToken() → refresh_token을 검증 후 새로운 access_token 발급
     c. removeRefreshToken() → 로그아웃 시 refresh token 삭제

-   **main.ts**
    a. cookie-parser 적용
    b. enableCors({ credentials: true }) 추가하여 쿠키 포함 요청 허용

