### PR TITLE
프론트 요청 기능 반영 (인증 및 데이터)

### DIFF
--- a/prisma/mysql.schema.prisma
+++ b/prisma/mysql.schema.prisma
@@ -47,7 +47,7 @@ model Subscriber {
 // OAuthToken 모델
 model OAuthToken {
   id           Int      @id @default(autoincrement())
-  userId       Int
+  userId       Int      @unique
   accessToken  String   @db.Text
   refreshToken String   @db.Text
   expiresAt    DateTime

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -47,10 +47,17 @@ export class AuthController {
       return res.status(401).json({ message: 'User validation failed' });
     }
 
-    const accessToken = await this.authService.generateAccessToken(user.id, user.email);
+    const accessToken = await this.authService.generateAccessToken(
+      user.id,
+      user.email,
+    );
     const refreshToken = await this.authService.generateRefreshToken(user.id);
 
-    await this.authService.storeRefreshToken(user.id, accessToken, refreshToken);
+    await this.authService.storeRefreshToken(
+      user.id,
+      accessToken,
+      refreshToken,
+    );
 
     res.cookie('access_token', accessToken, {
       httpOnly: true,
@@ -73,7 +80,9 @@ export class AuthController {
                 email: user.email,
                 username: user.username,
                 profileImg: user.profileImg,
-              }).replace(/\\/g, '\\\\').replace(/'/g, "\\'")};
+              })
+                .replace(/\\/g, '\\\\')
+                .replace(/'/g, "\\'")};
 
               if (window.opener) {
                 window.opener.postMessage({ type: 'oauthSuccess', token, user }, '${frontendUrl}');
@@ -103,7 +112,10 @@ export class AuthController {
       return res.status(401).json({ message: 'Unauthorized' });
     }
 
-    const newAccessToken = await this.authService.refreshAccessToken(userId, refreshToken);
+    const newAccessToken = await this.authService.refreshAccessToken(
+      userId,
+      refreshToken,
+    );
 
     if (!newAccessToken) {
       return res.status(401).json({ message: 'Invalid refresh token' });

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -46,7 +46,11 @@ export class AuthService {
     );
   }
 
-  async storeRefreshToken(userId: number, accessToken: string, refreshToken: string) {
+  async storeRefreshToken(
+    userId: number,
+    accessToken: string,
+    refreshToken: string,
+  ) {
     await this.prisma.oAuthToken.upsert({
       where: { userId: userId },
       update: {

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -23,7 +23,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
 
   async validate(payload: any) {
     return {
-      id: payload.sub, // ✅ 수정됨
+      id: payload.sub, // 수정됨
       email: payload.email,
       username: payload.username,
       profileImg: payload.profileImg,

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -23,7 +23,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
 
   async validate(payload: any) {
     return {
-      userId: payload.sub,
+      id: payload.sub, // ✅ 수정됨
       email: payload.email,
       username: payload.username,
       profileImg: payload.profileImg,

--- a/src/feedback/feedback.controller.ts
+++ b/src/feedback/feedback.controller.ts
@@ -1,21 +1,29 @@
-import { Controller, Post, Delete, Body } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  Delete,
+  Body,
+  Req,
+  UseGuards,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { FeedbackService } from './feedback.service';
+import { AuthGuard } from '@nestjs/passport';
+import { Request } from 'express';
 
 @Controller('feedback')
+@UseGuards(AuthGuard('jwt')) // JWT 인증 적용
 export class FeedbackController {
   constructor(private readonly feedbackService: FeedbackService) {}
 
   @Post('bookmark')
   async addBookmark(
-    @Body()
-    body: {
-      userId: number;
-      newsId: number;
-      newsletterId?: number;
-      rating?: number;
-    },
+    @Req() req: Request, // JWT에서 userId 자동 추출
+    @Body() body: { newsId: number; newsletterId?: number; rating?: number }, // userId 제외
   ) {
-    const { userId, newsId, newsletterId, rating } = body;
+    const user = req.user as { id: number }; // 명확한 타입 지정
+    const userId = this.extractUserId(user.id);
+    const { newsId, newsletterId, rating } = body;
     return this.feedbackService.addBookmark(
       userId,
       newsId,
@@ -25,8 +33,20 @@ export class FeedbackController {
   }
 
   @Delete('bookmark')
-  async removeBookmark(@Body() body: { userId: number; newsId: number }) {
-    const { userId, newsId } = body;
+  async removeBookmark(
+    @Req() req: Request, // JWT에서 userId 자동 추출
+    @Body() body: { newsId: number }, // userId 제외
+  ) {
+    const user = req.user as { id: number }; // 명확한 타입 지정
+    const userId = this.extractUserId(user.id);
+    const { newsId } = body;
     return this.feedbackService.removeBookmark(userId, newsId);
+  }
+
+  private extractUserId(userId: string | number | undefined): number {
+    if (!userId) {
+      throw new UnauthorizedException('User not authenticated');
+    }
+    return typeof userId === 'string' ? parseInt(userId, 10) : userId;
   }
 }

--- a/src/mypage/mypage.service.ts
+++ b/src/mypage/mypage.service.ts
@@ -44,6 +44,13 @@ export class MyPageService {
             imageUrl: true, // news-img 추가
             content: true, // news-summary 추가 (100자 제한)
             createdAt: true, // news-createdAt 추가
+            category: {
+              // 카테고리 정보 추가
+              select: {
+                id: true,
+                name: true, // 카테고리 이름 추가
+              },
+            },
           },
         },
       },
@@ -55,12 +62,18 @@ export class MyPageService {
 
     return bookmarks.map((bookmark) => ({
       id: bookmark.newsletter?.id,
-      newsTitle: bookmark.newsletter?.title, // 추가
-      newsImg: bookmark.newsletter?.imageUrl || null, // 추가 (이미지 없으면 null)
-      newsCreatedAt: bookmark.newsletter?.createdAt, // 추가 (뉴스 생성 날짜)
+      newsTitle: bookmark.newsletter?.title,
+      newsImg: bookmark.newsletter?.imageUrl || null,
+      newsCreatedAt: bookmark.newsletter?.createdAt,
       newsSummary: bookmark.newsletter?.content
-        ? bookmark.newsletter.content.substring(0, 100) + '...' // 추가 (100자 요약)
+        ? bookmark.newsletter.content.substring(0, 100) + '...'
         : null,
+      category: bookmark.newsletter?.category
+        ? {
+            id: bookmark.newsletter.category.id,
+            name: bookmark.newsletter.category.name,
+          }
+        : null, // 카테고리 정보 포함
     }));
   }
 


### PR DESCRIPTION
## 작업 개요

- **쿠키 기반 인증 적용**: 기존 Authorization 헤더 기반 인증에서 **httpOnly 쿠키를 사용하는 방식으로 변경**
- **북마크 기능 개선**: 북마크 등록/삭제 기능을 쿠키 인증으로 변경하였으며, 마이페이지에서 북마크 조회 시 **뉴스의 카테고리** 정보도 추가.


## PR 유형

어떤 변경 사항이 있나요?

-   새로운 기능 추가
-   코드 리팩토링


## 주요 변경 사항

1. **쿠키 기반 인증 적용 (`auth.controller.ts`, `jwt.strategy.ts`)**
   - `access_token`을 **httpOnly 쿠키**에 저장하여 보안 강화 (+ user_id도 포함되어 있음)
   - `refresh_token`을 **백엔드 서버에서만 관리**하여 클라이언트에 노출되지 않도록 수정
   -  모든 API 요청에서  자동으로 사용자 인증 적용

2. **북마크 기능 개선 (`feedback.controller.ts`, `feedback.service.ts`)**
   - `POST 와 DELETE`에서 쿠키 인증 방식으로 변경
   - `req.user.id`를 사용하여 userId 를 직접 전달할 필요 없음

3. **북마크 조회 시 뉴스 카테고리 정보 추가 (`mypage.controller.ts`, `mypage.service.ts`)**
   - 북마크된 뉴스의 카테고리 정보(category) 포함


### 테스트 결과 (선택)
![스크린샷 2025-01-31 오후 6 58 14](https://github.com/user-attachments/assets/3343fa40-155d-4997-90db-5fe585c4d742)

<img width="1133" alt="스크린샷 2025-01-31 오후 7 34 40" src="https://github.com/user-attachments/assets/5cbeecc3-75d5-4aeb-b59c-64b55d577a89" />


## 기타 참고 사항

-  프론트엔드에서 API 요청 시 `Authorization` 헤더 없이도 자동으로 인증 됨.
- 프리즈마 스키마 변경있으니 적용해주시면 감사하겠습니다.
