### PR TITLE
Feat/newsletter refactor

### DIFF
--- a/src/mail/mail.service.ts
+++ b/src/mail/mail.service.ts
@@ -69,7 +69,7 @@ export class MailService {
   }
 
   async sendBulkMailWithMultipleNewsletter(
-    subscribers: { email: string; interests: NewsCategory[] }[],
+    subscribers: { email: string; interests: string[] }[],
     newsletterArray: Newsletter[],
     basicIntroductionAsHTML?: string,
   ) {
@@ -86,7 +86,7 @@ export class MailService {
         subscribers.map(async (subscriber) => {
           const filteredNewsletter = newsletterArray.filter((newsletter) =>
             subscriber.interests.some(
-              (interest) => interest.id === newsletter.categoryId,
+              (interest) => parseInt(interest, 10) === newsletter.categoryId,
             ),
           );
           const newsletterWithTemplate = filteredNewsletter.map((newsletter) =>

--- a/src/mypage/mypage.controller.ts
+++ b/src/mypage/mypage.controller.ts
@@ -11,7 +11,7 @@ import { AuthGuard } from '@nestjs/passport';
 import { MyPageService } from './mypage.service';
 
 @Controller('mypage')
-@UseGuards(AuthGuard('jwt')) // JWT 인증 적용
+// @UseGuards(AuthGuard('jwt')) // JWT 인증 적용
 export class MyPageController {
   constructor(private readonly myPageService: MyPageService) {}
 
@@ -62,19 +62,31 @@ export class MyPageController {
   }
 
   /**
-   * 관심사 수정
+   * 관심사 더하긴
    */
   @Patch('interests')
-  async updateInterests(@Req() req, @Body('interests') interests: string[]) {
-    const userId = this.validateAndParseUserId(req.user?.id);
-    const validInterests = ['정치', '사회', 'IT'];
+  async addInterests(@Body() data: { categoryId: number; userId: number }) {
+    const categoryId = Number(data.categoryId);
+    const userId = this.validateAndParseUserId(data.userId);
+    const changedInterests = await this.myPageService.addInterests(
+      userId,
+      categoryId,
+    );
+    return changedInterests;
+  }
 
-    // 유효성 검사
-    if (!interests || interests.some((interest) => !validInterests.includes(interest))) {
-      throw new UnauthorizedException('Invalid interests provided');
-    }
-
-    return this.myPageService.updateInterests(userId, interests);
+  /**
+   * 관심사 삭제
+   */
+  @Patch('interests/remove')
+  async removeInterests(@Body() data: { categoryId: number; userId: number }) {
+    const categoryId = Number(data.categoryId);
+    const userId = this.validateAndParseUserId(data.userId);
+    const changedInterests = await this.myPageService.removeInterests(
+      userId,
+      categoryId,
+    );
+    return changedInterests;
   }
 
   /**

--- a/src/mypage/mypage.controller.ts
+++ b/src/mypage/mypage.controller.ts
@@ -11,7 +11,7 @@ import { AuthGuard } from '@nestjs/passport';
 import { MyPageService } from './mypage.service';
 
 @Controller('mypage')
-// @UseGuards(AuthGuard('jwt')) // JWT 인증 적용
+@UseGuards(AuthGuard('jwt')) // JWT 인증 적용
 export class MyPageController {
   constructor(private readonly myPageService: MyPageService) {}
 
@@ -56,8 +56,8 @@ export class MyPageController {
    * 관심사 조회
    */
   @Get('interests')
-  async getInterests(@Req() req) {
-    const userId = this.validateAndParseUserId(req.user?.id);
+  async getInterests(@Body() data: { userId: number }) {
+    const userId = this.validateAndParseUserId(data.userId);
     return this.myPageService.getInterests(userId);
   }
 

--- a/src/repository/newsletter.repository.ts
+++ b/src/repository/newsletter.repository.ts
@@ -49,6 +49,11 @@ export class NewsletterRepo {
       orderBy: { createdAt: 'asc' },
     });
   }
+  async getNewsletterByDateRange(dateStart: Date, dateEnd: Date) {
+    return this.prisma.newsletter.findMany({
+      where: { createdAt: { gte: dateStart, lte: dateEnd } },
+    });
+  }
 
   async getNewsletterByCategoryIdAndDate(
     categoryId: number,

--- a/src/scheduler/scheduler.controller.ts
+++ b/src/scheduler/scheduler.controller.ts
@@ -83,7 +83,10 @@ export class SchedulerController {
     this.logger.log(`구독자 목록을 가져왔습니다.${recievers}`);
     const newsletters = await this.newsletterRepository.getNewsletter(0, 3);
     const mail = await this.mailService.sendBulkMailWithMultipleNewsletter(
-      recievers,
+      recievers.map((reciever) => ({
+        email: reciever.email,
+        interests: reciever.interests.map((interest) => interest.name),
+      })),
       newsletters,
       '테스트 입니다. \n 이곳에는 요약 뉴스가 들어갑니다.',
     );

--- a/src/scheduler/scheduler.controller.ts
+++ b/src/scheduler/scheduler.controller.ts
@@ -55,9 +55,13 @@ export class SchedulerController {
       cycle: this.schedulerService.getMailSendCycle(),
     };
   }
-  @Get('mail-send-cycle')
-  getMailSendCycle() {
-    return this.schedulerService.getMailSendCycle();
+  @Post('start-crawling')
+  startCrawling() {
+    this.schedulerService.manualStartCrawling();
+    return {
+      success: true,
+      message: '크롤링 시작되었습니다.',
+    };
   }
   @Post('start-ai-summary')
   startAiSummary() {
@@ -67,14 +71,18 @@ export class SchedulerController {
       message: 'AI 요약 시작되었습니다.',
     };
   }
-
-  @Post('start-crawling')
-  startCrawling() {
-    this.schedulerService.manualStartCrawling();
+  @Post('start-mail-send')
+  startMailSend() {
+    this.schedulerService.manualStartMailSend();
     return {
       success: true,
-      message: '크롤링 시작되었습니다.',
+      message: '메일 발송 시작되었습니다.',
     };
+  }
+
+  @Get('mail-send-cycle')
+  getMailSendCycle() {
+    return this.schedulerService.getMailSendCycle();
   }
 
   @Get('mailtest') // 테스트용
@@ -85,7 +93,8 @@ export class SchedulerController {
     const mail = await this.mailService.sendBulkMailWithMultipleNewsletter(
       recievers.map((reciever) => ({
         email: reciever.email,
-        interests: reciever.interests.map((interest) => interest.name),
+        interests: reciever.interests,
+        name: reciever.name,
       })),
       newsletters,
       '테스트 입니다. \n 이곳에는 요약 뉴스가 들어갑니다.',

--- a/src/scheduler/scheduler.service.ts
+++ b/src/scheduler/scheduler.service.ts
@@ -111,36 +111,55 @@ export class SchedulerService {
   })
   async sendEmailSummary() {
     const subscribers = await this.subscriberService.getSubscribers();
-    const categoryList = await this.categoryRepository.findAll();
+    this.logger.debug(`구독자 수: ${subscribers.length}`);
+
     if (subscribers.length === 0) {
       throw new NotFoundException('구독자가 없습니다.');
       return;
     }
-    if (categoryList.length === 0) {
-      throw new NotFoundException('카테고리가 없습니다.');
+
+    // 관심사가 설정된 구독자만 필터링
+    const validSubscribers = subscribers.filter(
+      (subscriber) => subscriber.interests && subscriber.interests.length > 0,
+    );
+
+    if (validSubscribers.length === 0) {
+      this.logger.warn('관심사가 설정된 구독자가 없습니다.');
       return;
     }
-    for (const category of categoryList) {
-      const newsletters =
-        await this.newsletterRepository.getNewsletterByCategoryIdAndDate(
-          category.id,
-          dayjs().subtract(7, 'day').toDate(),
-          dayjs().toDate(),
-        );
-      const basicIntroduction = newsletters[0].content; //일시적으로 첫번째 뉴스를 기준으로 함
-      const basicIntroductionAsHTML =
-        await this.htmlFormatterService.formatHtml(basicIntroduction);
 
-      const result = await this.mailService.sendBulkMailWithMultipleNewsletter(
-        subscribers.map((subscriber) => ({
-          email: subscriber.email,
-          interests: subscriber.interests.map((interest) => interest.name),
-        })),
-        newsletters,
-        basicIntroductionAsHTML,
+    // 지난 7일간의 모든 뉴스레터를 한번에 가져옵니다
+    const allNewsletters =
+      await this.newsletterRepository.getNewsletterByDateRange(
+        dayjs().subtract(7, 'day').toDate(),
+        dayjs().toDate(),
       );
-      this.logger.log(`발송 결과 ${result.message}`);
+
+    this.logger.debug(`기간 내 뉴스레터 수: ${allNewsletters.length}`);
+
+    if (!allNewsletters.length) {
+      this.logger.debug('기간 내 뉴스레터가 없습니다.');
+      return;
     }
+
+    // 첫 번째 뉴스레터의 content를 기본 소개글로 사용 (일시적)
+    const basicIntroductionAsHTML = allNewsletters[0].contentAsHTML
+      .replace(/```/gm, '')
+      .replace(/html/gm, '');
+
+    const result = await this.mailService.sendBulkMailWithMultipleNewsletter(
+      validSubscribers.map((subscriber) => ({
+        email: subscriber.email,
+        interests: subscriber.interests,
+        name: subscriber.name,
+      })),
+      allNewsletters,
+      basicIntroductionAsHTML,
+    );
+
+    this.logger.log(
+      `발송 결과 ${result.details.filter((r) => r.success).length}건 성공, ${result.details.filter((r) => !r.success).length}건 실패`,
+    );
   }
 
   toggleCrawlingScheduler(enable: boolean) {
@@ -185,6 +204,14 @@ export class SchedulerService {
       await this.makeAiSummary(); // 직접 메서드 호출
     } catch (error) {
       this.logger.error(`수동 AI 요약 실패: ${error.message}`);
+    }
+  }
+  async manualStartMailSend() {
+    this.logger.debug('메일 발송 수동 시작');
+    try {
+      await this.sendEmailSummary(); // 직접 메서드 호출
+    } catch (error) {
+      this.logger.error(`수동 메일 발송 실패: ${error.message}`);
     }
   }
 

--- a/src/scheduler/scheduler.service.ts
+++ b/src/scheduler/scheduler.service.ts
@@ -95,15 +95,15 @@ export class SchedulerService {
       this.logger.error(`AI 요약 실패: ${error.message}`);
     }
   }
-  @Cron(CronExpression.EVERY_5_SECONDS)
-  async sendAiSummary() {
-    const subscribers = await this.subscriberService.getSubscribers();
-    if (subscribers.length === 0) {
-      throw new NotFoundException('구독자가 없습니다.');
-      return;
-    }
-    this.logger.debug(subscribers[0]);
-  }
+  // @Cron(CronExpression.EVERY_5_SECONDS)
+  // async sendAiSummary() {
+  //   const subscribers = await this.subscriberService.getSubscribers();
+  //   if (subscribers.length === 0) {
+  //     throw new NotFoundException('구독자가 없습니다.');
+  //     return;
+  //   }
+  //   this.logger.debug(subscribers[0]);
+  // }
 
   // 주간 요약 뉴스 발송
   @Cron(CronExpression.EVERY_MONDAY_AT_8AM, {
@@ -132,7 +132,10 @@ export class SchedulerService {
         await this.htmlFormatterService.formatHtml(basicIntroduction);
 
       const result = await this.mailService.sendBulkMailWithMultipleNewsletter(
-        subscribers,
+        subscribers.map((subscriber) => ({
+          email: subscriber.email,
+          interests: subscriber.interests.map((interest) => interest.name),
+        })),
         newsletters,
         basicIntroductionAsHTML,
       );

--- a/src/subscriber/subscriber.service.ts
+++ b/src/subscriber/subscriber.service.ts
@@ -5,7 +5,6 @@ import {
   Logger,
 } from '@nestjs/common';
 import { MysqlPrismaService } from 'prisma/mysql.service'; // MysqlPrismaService 사용
-import { NewsCategory } from '@prisma/client';
 @Injectable()
 export class SubscriberService {
   constructor(
@@ -143,7 +142,8 @@ export class SubscriberService {
   async getSubscribers(): Promise<
     {
       email: string;
-      interests: NewsCategory[];
+      interests: number[];
+      name: string;
     }[]
   > {
     const recievers = await this.prisma.subscriber.findMany({
@@ -161,7 +161,8 @@ export class SubscriberService {
     const subscribersWithInterest = recievers.map((reciever) => {
       return {
         email: reciever.user.email,
-        interests: reciever.user.interests as NewsCategory[],
+        interests: reciever.user.interests as number[],
+        name: reciever.user.username,
       };
     });
 


### PR DESCRIPTION
## 작업 개요

1. 유저 interests 에 관심사 저장방식을 id로 저장합니다. 이전 방식대로 string으로 저장하면 불필요한 변환과 db 검색과정이 생기게 됩니다. 
2. 메일 발송 로직을 테스트 완료 했습니다. (수동 트리거 하는 endpoint도 만들어 두었습니다. `/scheduler/start-mail-send`)로 body 없이 post 날리면 됩니다.
3. 마찬가지로 ai 요약도 수동 트리거도 있습니다 (`/scheduler/start-ai-summary`)

## PR 유형

어떤 변경 사항이 있나요?

-   [X] 새로운 기능 추가
-   [X] 버그 수정
-   [ ] CSS 등 사용자 UI 디자인 변경
-   [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
-   [X] 코드 리팩토링
-   [ ] 주석 추가 및 수정
-   [ ] 문서 수정
-   [ ] 테스트 추가, 테스트 리팩토링
-   [ ] 빌드 부분 혹은 패키지 매니저 수정
-   [ ] 파일 혹은 폴더명 수정
-   [ ] 파일 혹은 폴더 삭제

